### PR TITLE
Lock the chrome driver version. Travis CI only has chrome 55 and the …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 script:
   - npm run ng test -- --single-run=true --browsers Chrome --code-coverage
   - ./node_modules/codecov/bin/codecov
-  - npm run ng e2e
-  - npm run ng lint
-  - npm run ng build -- --prod
+  - npm run e2e
+  - npm run lint
+  - npm run build -- --prod

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "pree2e": "webdriver-manager update --versions.chrome=2.28",
+    "e2e": "ng e2e --webdriver-update false"
   },
   "private": false,
   "dependencies": {


### PR DESCRIPTION
…latest chrome driver only supports chrome >= 56. When travis has a chrome browser >= 56 we can revert this commit